### PR TITLE
修复Linux下的构建

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.6.1",
     "@tauri-apps/api": "^2.0.1",
     "@tauri-apps/plugin-autostart": "^2.2.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -13,7 +13,6 @@ use std::cmp::min;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use std::{path::Path, process::Command, sync::Arc};
-use std::os::windows::process::CommandExt;
 #[cfg(desktop)]
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::path::BaseDirectory;
@@ -28,6 +27,9 @@ use tokio::task::JoinHandle;
 
 #[cfg(target_os = "macos")]
 use crate::utils::macos::add_event;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 
 #[tauri::command]
 pub async fn login(


### PR DESCRIPTION
修复了以下问题：

1. std::os::windows在Linux上不可用，这会导致Linux上cargo tauri build失败
2. package.json中缺少@ant-design/icons，这会导致使用npm以外的其他包管理器的用户安装依赖不完全

