### PR TITLE
fix: 强制使用 https 请求 zdbk 修复成绩查询失败问题

### DIFF
--- a/src-tauri/src/zju_assist.rs
+++ b/src-tauri/src/zju_assist.rs
@@ -184,8 +184,8 @@ impl ZjuAssist {
             .unwrap();
 
         tokio::pin! {
-            let latency_default = measure_latency(client_default, "http://zdbk.zju.edu.cn/");
-            let latency_no_proxy = measure_latency(client_no_proxy, "http://zdbk.zju.edu.cn/");
+            let latency_default = measure_latency(client_default, "https://zdbk.zju.edu.cn/");
+            let latency_no_proxy = measure_latency(client_no_proxy, "https://zdbk.zju.edu.cn/");
         }
 
         let latency_default_result;
@@ -306,7 +306,7 @@ impl ZjuAssist {
             self.get("https://tgmedia.cmc.zju.edu.cn/index.php?r=auth/login&auType=cmc&tenant_code=112&forward=https%3A%2F%2Fclassroom.zju.edu.cn%2F")
                 .send()
                 .await?;
-            self.post("https://zjuam.zju.edu.cn/cas/login?service=http://zdbk.zju.edu.cn/jwglxt/xtgl/login_ssologin.html")
+            self.post("https://zjuam.zju.edu.cn/cas/login?service=https://zdbk.zju.edu.cn/jwglxt/xtgl/login_ssologin.html")
                 .send()
                 .await?;
             self.have_login = true;
@@ -930,7 +930,7 @@ impl ZjuAssist {
 
         let res = self
             .post(format!(
-                "http://zdbk.zju.edu.cn/jwglxt/xtgl/index_cxMyCosJxpj.html?gnmkdm=N5083&su={}",
+                "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_cxMyCosJxpj.html?gnmkdm=N5083&su={}",
                 self.username
             ))
             .send()
@@ -943,7 +943,7 @@ impl ZjuAssist {
 
             let res = self
                 .post(format!(
-                    "http://zdbk.zju.edu.cn/jwglxt/xtgl/index_cxMyCosJxpj.html?gnmkdm=N5083&su={}",
+                    "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_cxMyCosJxpj.html?gnmkdm=N5083&su={}",
                     self.username
                 ))
                 .send()
@@ -992,7 +992,7 @@ impl ZjuAssist {
         if json.is_err() {
             self.relogin().await?;
 
-            let res = self.post(format!("http://zdbk.zju.edu.cn/jwglxt/cxdy/xscjcx_cxXscjIndex.html?doType=query&gnmkdm=N5083&su={}", self.username))
+            let res = self.post(format!("https://zdbk.zju.edu.cn/jwglxt/cxdy/xscjcx_cxXscjIndex.html?doType=query&gnmkdm=N5083&su={}", self.username))
                 .form(&data)
                 .send()
                 .await?;


### PR DESCRIPTION
## 问题原因

目前教务系统强制要求 https，原代码中 `zju_assist.rs` 使用 `http://zdbk.zju.edu.cn/` 发起 POST 请求时，遇到了 302 重定向到 https。在此重定向过程中，原有的请求参数和 Session Cookie 会丢失，导致到达最终接口时处于未登录状态，返回了 HTML 登录页面的代码。

## 修复方式

将 `zju_assist.rs` 中所有硬编码的 `http://zdbk.zju.edu.cn/` 替换为了 `https://zdbk.zju.edu.cn/`，本地测试已确认能成功获取成绩。

## 关联 Issue

Fixes #27 

## 关于其他的 PR：

注意到 PR #32 也在尝试解决此问题并增加了一些待办事项功能，但仍未能修改 http 导致的问题。本 PR 专门提供了一个针对此 Bug 的纯净修复版本，便于作者 review 和直接合并。